### PR TITLE
GitHub Workflows: add quote to cpio output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         go install github.com/u-root/mkuimage/cmd/mkuimage@latest
         go install github.com/hugelgupf/vmtest/tools/runvmtest@latest
         GOARCH=${{ matrix.arch }} mkuimage -config=default \
-          -o ${{ matrix.arch }}-${{ matrix.template }}.cpio \
+          -o "${{ matrix.arch }}-${{ matrix.template }}.cpio" \
           ${{ matrix.template }}
         xz --check=crc32 -9 --lzma2=dict=1MiB \
           --stdout ${{ matrix.arch }}-${{ matrix.template }}.cpio | \


### PR DESCRIPTION
The command to build trips when running for 'boot core'.

Signed-off-by: Daniel Maslowski <info@orangecms.org>
